### PR TITLE
set overflow scrolling to auto

### DIFF
--- a/src/components/stages/StageWithProposals.tsx
+++ b/src/components/stages/StageWithProposals.tsx
@@ -35,7 +35,7 @@ const ProposalsContainer = styled.div`
   gap: 2rem;
   flex: 1;
   display: flex;
-  overflow: scroll;
+  overflow: auto;
 `
 
 interface Props {


### PR DESCRIPTION
Rather than overflow; scroll, which forces x and y scroll bars, try overflow auto, that will add only the horz scroll bars when needed.

windows doesn't auto-hide scrollbars on users, so they can look jarringly unecessary.

![image](https://user-images.githubusercontent.com/1576283/141820913-f965826f-7c85-4a72-85c1-b21055abad91.png)
